### PR TITLE
ミスって変なとこで作業してた

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2024"
 [dependencies]
 axum = { version = "0.8.4", features = ["http2", "multipart", "ws"] }
 futures-util = "0.3.31"
+serde = { version = "1.0.219", features = ["derive"] }
 tokio = { version = "1.45.1", features = ["rt-multi-thread"] }
 tower-http = { version = "0.6.4", features = ["fs"] }


### PR DESCRIPTION
## Sourcery によるサマリー

接続状況の追跡、アイドル状態に基づいたクリーンアップのスケジュール、およびより豊富なルームリストのエンドポイント、インタラクティブな CLI コマンド、およびgraceful shutdownによる運用制御の改善により、ルームのライフサイクル管理を強化します。

新機能：
- ルームごとのアクティブな WebSocket 接続を追跡
- 接続数とともにルーム名を返すルームリスト API を公開
- 設定可能なアイドルタイムアウト後に自動ルーム削除をスケジュール
- ランタイムサーバー制御のためのインタラクティブな CLI コマンド（exit/quit/stop, room(s)）をサポート

機能拡張：
- グローバルな定期的クリーンアップをルームごとのアイドルタイマーに置き換え
- タイムアウト、レート制限、およびサーバーポートの設定定数を導入
- STDIN コマンドを介してトリガーされるgraceful shutdownロジックを追加
- キャッチオールルートの代わりにルートパスから静的ファイルを提供

雑務：
- API レスポンスをシリアライズするための serde 依存関係を追加

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance room lifecycle management by tracking connections, scheduling idle-based cleanup, and improving operational controls with a richer room listing endpoint, interactive CLI commands, and graceful shutdown.

New Features:
- Track active WebSocket connections per room
- Expose room list API returning room names with connection counts
- Schedule automatic room removal after configurable idle timeout
- Support interactive CLI commands (exit/quit/stop, room(s)) for runtime server control

Enhancements:
- Replace global periodic cleanup with per-room idle timers
- Introduce configuration constants for timeouts, rate limits, and server port
- Add graceful shutdown logic triggered via STDIN commands
- Serve static files from root path instead of catch-all route

Chores:
- Add serde dependency for serializing API responses

</details>